### PR TITLE
Fix issue #5 by downgrading to alpine:3.12 image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13 as base
+FROM alpine:3.12 as base
 
 RUN apk add --no-cache \
       nodejs


### PR DESCRIPTION
As explained in #5, alpine >= 3.13 is not working properly on RaspberryPi. This Pull Request downgrades it to alpine:3.12 and fixes the issue.

To verify I built image `bohdantkachenko/zwave-js-server:latest` and tested on my RaspberryPi where I can no longer reproduce the issue with this fix.

```
$ docker run -it --rm -p 3005:3000 --name=zjs -v "$PWD/cache:/cache" -e NETWORK_KEY="17DFB0C1BED4CABFF54E4B5375E257B3" --privileged -e USB_PATH=/dev/ttyUSB1 bohdantkachenko/zwave-js-server:latest
Starting zwave-server: zwave-server --config options.js /dev/ttyUSB1
22:25:34.403 DRIVER   version 8.0.3
22:25:34.405 DRIVER
22:25:34.406 DRIVER   starting driver...
22:25:34.451 DRIVER   opening serial port /dev/ttyUSB1
22:25:34.487 DRIVER   serial port opened
22:25:34.491 SERIAL » [NAK]                                                                   (0x15)
22:25:36.006 DRIVER   loading configuration...
22:25:36.023 CONFIG   version 8.0.3
...
```